### PR TITLE
Fix ModuleNotFoundError in Main Window

### DIFF
--- a/autoclick_pro/gui/main_window.py
+++ b/autoclick_pro/gui/main_window.py
@@ -204,7 +204,7 @@ class MainWindow(QMainWindow):
         self.action_simulation.toggled.connect(self.on_simulation_toggled)
         self.action_capture.triggered.connect(self.on_capture)
         self.action_keymap.triggered.connect(self.on_keymap)
-        self.action_label_manager.triggered.connect(self.on_label_mana_codegenewr</)
+        self.action_label_manager.triggered.connect(self.on_label_manager)
         self.btn_detect_demo.clicked.connect(self.on_detect_demo)
         self.btn_detect_feature.clicked.connect(self.on_detect_feature)
         self.btn_loop_test.clicked.connect(self.on_loop_test)


### PR DESCRIPTION
This pull request addresses the issue of [32m`ModuleNotFoundError` in the `autoclick_pro` application by correcting the connection to the label manager action in the `main_window.py` file. The method `on_label_manager` was previously incorrectly referenced, which caused the module to fail to load properly. This fix ensures that the proper method is called when the action is triggered, resolving the error and allowing the application to run smoothly.

---

> This pull request was co-created with Cosine Genie

Original Task: [auto-clicker/7kkb6ywu7q4d](https://cosine.sh/p0drixu2k2bx/auto-clicker/task/7kkb6ywu7q4d)
Author: Janith Manodaya
