### PR TITLE
Fix Play Button Functionality to Default to Real Execution

### DIFF
--- a/autoclick_pro/gui/main_window.py
+++ b/autoclick_pro/gui/main_window.py
@@ -270,6 +270,8 @@ class MainWindow(QMainWindow):
                 }
             )
         self.engine.start(acts)
+        # Minimize the app window while playing so it doesn't obstruct or capture focus
+        self.showMinimized()
 
     def on_save(self):
         path, _ = QFileDialog.getSaveFileName(self, "Save Project", filter="Project JSON (*.json)")

--- a/autoclick_pro/gui/main_window.py
+++ b/autoclick_pro/gui/main_window.py
@@ -73,7 +73,8 @@ class MainWindow(QMainWindow):
         self.action_capture = QAction(std_icon("SP_FileIcon", "SP_DialogOpenButton"), "Capture Object", self)
         self.action_simulation = QAction("Simulation", self)
         self.action_simulation.setCheckable(True)
-        self.action_simulation.setChecked(True)
+        # Default to real execution; enable this to simulate without performing real clicks/keys
+        self.action_simulation.setChecked(False)
 
         # Shortcuts
         self.action_play.setShortcut("F5")


### PR DESCRIPTION
This pull request modifies the behavior of the play button in the main window of the auto-clicker application. Previously, the application defaulted to simulation mode, which caused the clicks and key sequences to not perform as expected while running the program. With this change, the application will now default to real execution mode, allowing the play button to function correctly and execute the recorded actions without any simulation. This ensures that users can experience the intended functionality of the auto-clicker directly when they click the play button.

---

> This pull request was co-created with Cosine Genie

Original Task: [auto-clicker/bn55znrc5r18](https://cosine.sh/p0drixu2k2bx/auto-clicker/task/bn55znrc5r18)
Author: Janith Manodaya
